### PR TITLE
Fix issue with drag and drop index positioning

### DIFF
--- a/knockout-sortable.js
+++ b/knockout-sortable.js
@@ -138,7 +138,7 @@
                 // drop an item above the 3rd visible item, but the 2nd visible item
                 // has an actual index of 5.
                 if (e.item.previousElementSibling) {
-                    newIndex = to().indexOf(ko.dataFor(e.item.previousElementSibling)) + 1;
+                    newIndex = to().indexOf(ko.dataFor(e.item.previousElementSibling)) + (newIndex > originalIndex ? 0 : 1);
                 }
 
                 // Remove sortables "unbound" element

--- a/knockout-sortable.js
+++ b/knockout-sortable.js
@@ -138,7 +138,8 @@
                 // drop an item above the 3rd visible item, but the 2nd visible item
                 // has an actual index of 5.
                 if (e.item.previousElementSibling) {
-                    newIndex = to().indexOf(ko.dataFor(e.item.previousElementSibling)) + (newIndex > originalIndex ? 0 : 1);
+                    newIndex = to().indexOf(ko.dataFor(e.item.previousElementSibling));
+                    newIndex += (newIndex > originalIndex ? 0 : 1);
                 }
 
                 // Remove sortables "unbound" element


### PR DESCRIPTION
- Fixes issue with data-bind: sortable element for  a non-computed observable array. Dragging an item from a smaller index (eg 0) to a greater index (eg 10) places the element one position after the desired drop position (eg newIndex + 1).

Note: Has not been tested with dragging/dropping with more than one collection.
