### PR TITLE
Fixed bundled plugin

### DIFF
--- a/knockout-sortable.js
+++ b/knockout-sortable.js
@@ -2,60 +2,11 @@
 
 (function (factory) {
 	"use strict";
-	//get ko ref via global or require
-	var koRef;
-	if (typeof ko !== 'undefined') {
-		//global ref already defined
-		koRef = ko;
+
+	if (typeof define === 'function' && define.amd) {
+		define(['knockout', './Sortable'], factory);
 	}
-	else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-		//commonjs / node.js
-		koRef = require('knockout');
-	}
-	//get sortable ref via global or require
-	var sortableRef;
-	if (typeof Sortable !== 'undefined') {
-		//global ref already defined
-		sortableRef = Sortable;
-	}
-	else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
-		//commonjs / node.js
-		sortableRef = require('sortablejs');
-	}
-	//use references if we found them
-	if (koRef !== undefined && sortableRef !== undefined) {
-		factory(koRef, sortableRef);
-	}
-	//if both references aren't found yet, get via AMD if available
-	else if (typeof define === 'function' && define.amd) {
-		//we may have a reference to only 1, or none
-		if (koRef !== undefined && sortableRef === undefined) {
-			define(['./Sortable'], function (amdSortableRef) {
-				factory(koRef, amdSortableRef);
-			});
-		}
-		else if (koRef === undefined && sortableRef !== undefined) {
-			define(['knockout'], function (amdKnockout) {
-				factory(amdKnockout, sortableRef);
-			});
-		}
-		else if (koRef === undefined && sortableRef === undefined) {
-			define(['knockout', './Sortable'], factory);
-		}
-	}
-	//no more routes to get references
-	else {
-		//report specific error
-		if (koRef !== undefined && sortableRef === undefined) {
-			throw new Error('knockout-sortable could not get reference to Sortable');
-		}
-		else if (koRef === undefined && sortableRef !== undefined) {
-			throw new Error('knockout-sortable could not get reference to Knockout');
-		}
-		else if (koRef === undefined && sortableRef === undefined) {
-			throw new Error('knockout-sortable could not get reference to Knockout or Sortable');
-		}
-	}
+
 })(function (ko, Sortable) {
     "use strict";
 


### PR DESCRIPTION
This change resolves an issue with bundling knockout sortable plugin. The original error message after bundling was about undefined define function. 